### PR TITLE
Add fast state diff bundle method

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -9,6 +9,7 @@ use alloy_rpc_types_engine::ExecutionData;
 use jsonrpsee::{core::middleware::layer::Either, RpcModule};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_provider::HashedPostStateProvider;
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineTypes, EngineValidator, FullNodeComponents, FullNodeTypes,
     NodeAddOns, NodeTypes, PayloadTypes, ReceiptTy,
@@ -626,7 +627,7 @@ where
 impl<N, EthB, EV, EB, RpcMiddleware> RpcAddOns<N, EthB, EV, EB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
+    N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks> + HashedPostStateProvider,
     EthB: EthApiBuilder<N>,
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
@@ -903,10 +904,12 @@ where
     }
 }
 
-impl<N, EthB, EV, EB, RpcMiddleware> NodeAddOns<N> for RpcAddOns<N, EthB, EV, EB, RpcMiddleware>
+impl<N, EthB, EV, EB, RpcMiddleware> NodeAddOns<N>
+    for RpcAddOns<N, EthB, EV, EB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
+    <N as FullNodeTypes>::Provider:
+        ChainSpecProvider<ChainSpec: EthereumHardforks> + HashedPostStateProvider,
     EthB: EthApiBuilder<N>,
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -55,6 +55,7 @@ use reth_optimism_txpool::{
     OpPooledTx,
 };
 use reth_provider::{providers::ProviderFactoryBuilder, CanonStateSubscriptions};
+use reth_provider::HashedPostStateProvider;
 use reth_rpc_api::{DebugApiServer, L2EthApiExtServer};
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
@@ -202,6 +203,7 @@ impl OpNode {
 impl<N> Node<N> for OpNode
 where
     N: FullNodeTypes<Types: OpFullNodeTypes + OpNodeTypes>,
+    <N as FullNodeTypes>::Provider: HashedPostStateProvider,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -238,6 +240,7 @@ where
 impl<N> DebugNode<N> for OpNode
 where
     N: FullNodeComponents<Types = Self>,
+    <N as FullNodeTypes>::Provider: HashedPostStateProvider,
 {
     type RpcBlock = alloy_rpc_types_eth::Block<op_alloy_consensus::OpTxEnvelope>;
 
@@ -433,6 +436,7 @@ where
     >,
     N::Types: NodeTypes<Primitives: OpPayloadPrimitives>,
     EthB: EthApiBuilder<N>,
+    <N as FullNodeTypes>::Provider: HashedPostStateProvider,
     <N::Pool as TransactionPool>::Transaction: OpPooledTx,
     EV: EngineValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
@@ -547,6 +551,7 @@ where
         Types: OpFullNodeTypes,
         Evm: ConfigureEvm<NextBlockEnvCtx = OpNextBlockEnvAttributes>,
     >,
+    <N as FullNodeTypes>::Provider: HashedPostStateProvider,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: OpPooledTx,
     EthB: EthApiBuilder<N>,
     EV: EngineValidatorBuilder<N>,

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -3,7 +3,10 @@ use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256};
 use alloy_rpc_types_debug::ExecutionWitness;
-use alloy_rpc_types_eth::{Block, Bundle, StateContext};
+use alloy_rpc_types_eth::{
+    state::StateOverride,
+    Block, BlockOverrides, Bundle, StateContext,
+};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
@@ -155,6 +158,18 @@ pub trait DebugApi<TxReq: RpcObject> {
         &self,
         hash: B256,
     ) -> RpcResult<ExecutionWitness>;
+
+    /// Executes the given transactions sequentially on top of the state at the provided block and
+    /// returns the hashed post state after execution. This behaves similar to block execution and
+    /// is optimized for speed.
+    #[method(name = "stateDiffBundle")]
+    async fn debug_state_diff_bundle(
+        &self,
+        txs: Vec<TxReq>,
+        block_id: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
+    ) -> RpcResult<HashedPostState>;
 
     /// Sets the logging backtrace location. When a backtrace location is set and a log message is
     /// emitted at that location, the stack of the goroutine executing the log statement will

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -51,8 +51,8 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{receipt::EthReceiptConverter, EthConfig, EthSubscriptionIdProvider};
 use reth_rpc_layer::{AuthLayer, Claims, CompressionLayer, JwtAuthValidator, JwtSecret};
 use reth_storage_api::{
-    AccountReader, BlockReader, BlockReaderIdExt, ChangeSetReader, FullRpcProvider, ProviderBlock,
-    StateProviderFactory,
+    AccountReader, BlockReader, BlockReaderIdExt, ChangeSetReader, FullRpcProvider,
+    HashedPostStateProvider, ProviderBlock, StateProviderFactory,
 };
 use reth_tasks::{pool::BlockingTaskGuard, TaskSpawner, TokioTaskExecutor};
 use reth_transaction_pool::{noop::NoopTransactionPool, TransactionPool};
@@ -317,7 +317,8 @@ where
     Provider: FullRpcProvider<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
         + CanonStateSubscriptions<Primitives = N>
         + AccountReader
-        + ChangeSetReader,
+        + ChangeSetReader
+        + HashedPostStateProvider,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
@@ -713,6 +714,7 @@ where
     where
         EthApi: EthApiSpec + EthTransactions + TraceExt,
         EvmConfig::Primitives: NodePrimitives<Block = ProviderBlock<EthApi::Provider>>,
+        EthApi::Provider: HashedPostStateProvider,
     {
         let debug_api = self.debug_api();
         self.modules.insert(RethRpcModule::Debug, debug_api.into_rpc().into());
@@ -822,6 +824,7 @@ where
     where
         EthApi: EthApiSpec + EthTransactions + TraceExt,
         EvmConfig::Primitives: NodePrimitives<Block = ProviderBlock<EthApi::Provider>>,
+        EthApi::Provider: HashedPostStateProvider,
     {
         DebugApi::new(
             self.eth_api().clone(),
@@ -856,7 +859,8 @@ where
     Provider: FullRpcProvider<Block = N::Block>
         + CanonStateSubscriptions<Primitives = N>
         + AccountReader
-        + ChangeSetReader,
+        + ChangeSetReader
+        + HashedPostStateProvider,
     Pool: TransactionPool + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -5,7 +5,8 @@ use alloy_primitives::{uint, Address, Bytes, B256};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_eth::{
-    state::EvmOverrides, Block as RpcBlock, BlockError, Bundle, StateContext, TransactionInfo,
+    state::{EvmOverrides, StateOverride},
+    Block as RpcBlock, BlockError, BlockOverrides, Bundle, StateContext, TransactionInfo,
 };
 use alloy_rpc_types_trace::geth::{
     call::FlatCallFrame, BlockTraceResult, FourByteFrame, GethDebugBuiltInTracerType,
@@ -33,11 +34,13 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
-    BlockIdReader, BlockReaderIdExt, HeaderProvider, ProviderBlock, ReceiptProviderIdExt,
-    StateProofProvider, StateProviderFactory, StateRootProvider, TransactionVariant,
+    BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
+    ReceiptProviderIdExt, StateProofProvider, StateProviderFactory, StateRootProvider,
+    TransactionVariant,
 };
 use reth_tasks::pool::BlockingTaskGuard;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
+use alloy_evm::overrides::{apply_block_overrides, apply_state_overrides};
 use revm::{context_interface::Transaction, state::EvmState, DatabaseCommit};
 use revm_inspectors::tracing::{
     FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig, TransactionContext,
@@ -80,6 +83,7 @@ impl<Eth, Evm> DebugApi<Eth, Evm>
 where
     Eth: EthApiTypes + TraceExt + 'static,
     Evm: ConfigureEvm<Primitives: NodePrimitives<Block = ProviderBlock<Eth::Provider>>> + 'static,
+    Eth::Provider: HashedPostStateProvider,
 {
     /// Acquires a permit to execute a tracing call.
     async fn acquire_trace_permit(&self) -> Result<OwnedSemaphorePermit, AcquireError> {
@@ -894,6 +898,59 @@ where
             })
             .await
     }
+
+    /// Executes the given transactions sequentially on top of the state at the provided block.
+    ///
+    /// This reuses the same execution strategy as block insertion which keeps the
+    /// state database warm and avoids additional tracing overhead. Optional
+    /// `state_overrides` and `block_overrides` behave the same as in
+    /// [`debug_traceCall`]. The method returns the resulting [`HashedPostState`]
+    /// that contains only the touched accounts and storage slots.
+    pub async fn debug_state_diff_bundle(
+        &self,
+        txs: Vec<RpcTxReq<Eth::NetworkTypes>>,
+        block_id: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
+    ) -> Result<HashedPostState, Eth::Error> {
+        let block_id = block_id.unwrap_or_default();
+        let ((mut evm_env, _), _) = futures::try_join!(
+            self.eth_api().evm_env_at(block_id),
+            self.eth_api().recovered_block(block_id)
+        )?;
+
+        let this = self.clone();
+        self.eth_api()
+            .spawn_with_state_at_block(block_id, move |state| {
+                let mut db = State::builder()
+                    .with_database(StateProviderDatabase::new(state))
+                    .with_bundle_update()
+                    .without_state_clear()
+                    .build();
+
+                if let Some(state_overrides) = state_overrides {
+                    apply_state_overrides(state_overrides, &mut db)
+                        .map_err(Eth::Error::from_eth_err)?;
+                }
+
+                if let Some(block_overrides) = block_overrides {
+                    apply_block_overrides(*block_overrides, &mut db, &mut evm_env.block_env);
+                }
+
+                for tx in txs {
+                    let (env, tx_env) = this
+                        .eth_api()
+                        .prepare_call_env(evm_env.clone(), tx, &mut db, EvmOverrides::default())?;
+                    let res = this.eth_api().transact(&mut db, env, tx_env)?;
+                    db.commit(res.state);
+                }
+
+                let bundle_state = db.take_bundle();
+                let hashed = this.eth_api().provider().hashed_post_state(&bundle_state);
+                Ok(hashed)
+            })
+            .await
+    }
 }
 
 #[async_trait]
@@ -901,6 +958,7 @@ impl<Eth, Evm> DebugApiServer<RpcTxReq<Eth::NetworkTypes>> for DebugApi<Eth, Evm
 where
     Eth: EthApiTypes + EthTransactions + TraceExt + 'static,
     Evm: ConfigureEvm<Primitives: NodePrimitives<Block = ProviderBlock<Eth::Provider>>> + 'static,
+    Eth::Provider: HashedPostStateProvider,
 {
     /// Handler for `debug_getRawHeader`
     async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes> {
@@ -1255,6 +1313,18 @@ where
         block_id: Option<BlockId>,
     ) -> RpcResult<(B256, TrieUpdates)> {
         Self::debug_state_root_with_updates(self, hashed_state, block_id).await.map_err(Into::into)
+    }
+
+    async fn debug_state_diff_bundle(
+        &self,
+        txs: Vec<RpcTxReq<Eth::NetworkTypes>>,
+        block_id: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
+    ) -> RpcResult<HashedPostState> {
+        Self::debug_state_diff_bundle(self, txs, block_id, state_overrides, block_overrides)
+            .await
+            .map_err(Into::into)
     }
 
     async fn debug_stop_cpu_profile(&self) -> RpcResult<()> {

--- a/docs/vocs/docs/pages/jsonrpc/debug.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/debug.mdx
@@ -102,3 +102,34 @@ The block can optionally be specified either by hash or by number as the second 
 | Client | Method invocation                                                     |
 | ------ | --------------------------------------------------------------------- |
 | RPC    | `{"method": "debug_traceCall", "params": [call, block_number, opts]}` |
+
+## `debug_stateDiffBundle`
+
+Executes a list of transactions sequentially on top of the state at the provided block and returns the resulting hashed post state.
+
+Example:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "debug_stateDiffBundle",
+  "params": [[{"from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1", "to": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b", "value": "0x186a0"}], "latest", null, null]
+}
+```
+
+Example output:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "accounts": {
+      "0x…": null,
+      "0x…": {"nonce": "0x1", "balance": "0x0", "bytecodeHash": "0x…"}
+    },
+    "storages": {}
+  }
+}
+```


### PR DESCRIPTION
## Summary
- add `stateDiffBundle` method to `DebugApi`
- document the new RPC call with example output
- clarify description for fast execution
- add missing trait bounds for HashedPostStateProvider

## Testing
- `cargo check -p reth-node-builder`
- `cargo check -p reth-optimism-node`
- `cargo check -p reth-rpc`


------
https://chatgpt.com/codex/tasks/task_e_687cdd9f79f48323b5b9d09cfb878dd4